### PR TITLE
fix(python): add import-time struct size guards and prepare 0.0.52.

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ For reference purposes you can find Xcode projects with these changes applied in
 
 #### Android
 
-On Android we publish [the package to Maven](https://mvnrepository.com/artifact/ai.moonshine/moonshine-voice). To include it in your project using Android Studio and Gradle, first add the version number you want to the `gradle/libs.versions.toml` file by inserting a line in the `[versions]` section, for example `moonshineVoice = "0.0.51"`. Then in the `[libraries]` part, add a reference to the package: `moonshine-voice = { group = "ai.moonshine", name = "moonshine-voice", version.ref = "moonshineVoice" }`.
+On Android we publish [the package to Maven](https://mvnrepository.com/artifact/ai.moonshine/moonshine-voice). To include it in your project using Android Studio and Gradle, first add the version number you want to the `gradle/libs.versions.toml` file by inserting a line in the `[versions]` section, for example `moonshineVoice = "0.0.52"`. Then in the `[libraries]` part, add a reference to the package: `moonshine-voice = { group = "ai.moonshine", name = "moonshine-voice", version.ref = "moonshineVoice" }`.
 
 Finally, in your `app/build.gradle.kts` add the library to the `dependencies` list: `implementation(libs.moonshine.voice)`. You can find a working example of all these changes in [`examples/android/Transcriber`].
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,7 @@ mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()
     
-    coordinates("ai.moonshine", "moonshine-voice", "0.0.51")
+    coordinates("ai.moonshine", "moonshine-voice", "0.0.52")
 
     pom {
         name.set("Moonshine Voice")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,7 +4,7 @@ project("moonshine")
 
 set(CMAKE_CXX_STANDARD 20)
 
-set(MOONSHINE_VERSION "0.0.51")
+set(MOONSHINE_VERSION "0.0.52")
 
 # Ensure the standard is strictly enforced (optional, but recommended)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/examples/android/Transcriber/gradle/libs.versions.toml
+++ b/examples/android/Transcriber/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ material = "1.13.0"
 constraintlayout = "2.2.1"
 navigationFragment = "2.9.4"
 navigationUi = "2.9.4"
-moonshineVoice = "0.0.51"
+moonshineVoice = "0.0.52"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/examples/ios/Transcriber/Transcriber.xcodeproj/project.pbxproj
+++ b/examples/ios/Transcriber/Transcriber.xcodeproj/project.pbxproj
@@ -580,7 +580,7 @@
 			repositoryURL = "https://github.com/moonshine-ai/moonshine-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.51;
+				minimumVersion = 0.0.52;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/macos/BasicTranscription/BasicTranscription.xcodeproj/project.pbxproj
+++ b/examples/macos/BasicTranscription/BasicTranscription.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 			repositoryURL = "https://github.com/moonshine-ai/moonshine-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.51;
+				minimumVersion = 0.0.52;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/macos/BasicTranscription/Package.swift
+++ b/examples/macos/BasicTranscription/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     dependencies: [
         // Uncomment this back in when you want to use the locally-built Swift package.
         // .package(path: "../../../swift")
-        .package(url: "https://github.com/moonshine-ai/moonshine-swift.git", from: "0.0.51")
+        .package(url: "https://github.com/moonshine-ai/moonshine-swift.git", from: "0.0.52")
     ],
     targets: [
         .executableTarget(

--- a/examples/macos/MicTranscription/MicTranscription.xcodeproj/project.pbxproj
+++ b/examples/macos/MicTranscription/MicTranscription.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 			repositoryURL = "https://github.com/moonshine-ai/moonshine-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.51;
+				minimumVersion = 0.0.52;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/examples/macos/MicTranscription/Package.swift
+++ b/examples/macos/MicTranscription/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     dependencies: [
         // Uncomment this back in when you want to use the locally-built Swift package.
         // .package(path: "../../../swift")
-        .package(url: "https://github.com/moonshine-ai/moonshine-swift.git", from: "0.0.51")
+        .package(url: "https://github.com/moonshine-ai/moonshine-swift.git", from: "0.0.52")
     ],
     targets: [
         .executableTarget(

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "moonshine-voice"
-version = "0.0.51"
+version = "0.0.52"
 description = "Fast, accurate, on-device AI library for building interactive voice applications"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/python/setup.py
+++ b/python/setup.py
@@ -46,7 +46,7 @@ def read_requirements():
 
 setup(
     name="moonshine-voice",
-    version="0.0.51",
+    version="0.0.52",
     description="Fast, accurate, on-device AI library for building interactive voice applications",
     long_description=read_readme(),
     long_description_content_type="text/markdown",

--- a/python/src/moonshine_voice/__init__.py
+++ b/python/src/moonshine_voice/__init__.py
@@ -39,7 +39,7 @@ from moonshine_voice.utils import (
     load_wav_file,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.0.52"
 
 # Lazy imports to avoid RuntimeWarning when running modules as scripts
 # These will be imported on first access via __getattr__

--- a/python/src/moonshine_voice/moonshine_api.py
+++ b/python/src/moonshine_voice/moonshine_api.py
@@ -53,6 +53,30 @@ class TranscriptC(ctypes.Structure):
     ]
 
 
+def _require_struct_size(struct_name, struct_type, expected_size, extra_message=""):
+    """Fail fast if a ctypes definition drifts from the compiled C ABI."""
+    actual_size = ctypes.sizeof(struct_type)
+    if actual_size != expected_size:
+        message = (
+            f"{struct_name} size mismatch: expected {expected_size}, got "
+            f"{actual_size}. Python ctypes binding is out of sync with "
+            "moonshine-c-api.h."
+        )
+        if extra_message:
+            message = f"{message} {extra_message}"
+        raise ImportError(message)
+
+
+_require_struct_size("TranscriptWordC", TranscriptWordC, 24)
+_require_struct_size(
+    "TranscriptLineC",
+    TranscriptLineC,
+    80,
+    "See https://github.com/moonshine-ai/moonshine/issues/158",
+)
+_require_struct_size("TranscriptC", TranscriptC, 16)
+
+
 class TranscriberOptionC(ctypes.Structure):
     """C structure for transcriber_option_t."""
 

--- a/scripts/publish-binary.bat
+++ b/scripts/publish-binary.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal enabledelayedexpansion
 
-set VERSION=0.0.51
+set VERSION=0.0.52
 set REPO=moonshine-ai/moonshine
 
 REM Get the directory where this script is located

--- a/scripts/publish-binary.sh
+++ b/scripts/publish-binary.sh
@@ -1,6 +1,6 @@
 #! /bin/bash -ex
 
-VERSION=0.0.51
+VERSION=0.0.52
 REPO="moonshine-ai/moonshine"
 
 SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/publish-swift.sh
+++ b/scripts/publish-swift.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 FRAMEWORK_NAME="Moonshine"
-VERSION="0.0.51"
+VERSION="0.0.52"
 REPO="moonshine-ai/moonshine-swift"
 
 # Check that the XCFramework exists

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -9,6 +9,7 @@ KNOWN_FILES=(
 	./core/CMakeLists.txt
 	./python/pyproject.toml
 	./python/setup.py
+	./python/src/moonshine_voice/__init__.py
 	./build.gradle.kts
 	./examples/macos/BasicTranscription/BasicTranscription.xcodeproj/project.pbxproj
 	./examples/macos/BasicTranscription/Package.swift


### PR DESCRIPTION
# PR Description

## Summary

- add import-time ctypes ABI guards for `TranscriptWordC`, `TranscriptLineC`, and `TranscriptC` so Python fails fast with `ImportError` instead of crashing when the binding drifts from `moonshine-c-api.h`
- bump the repo release metadata from `0.0.51` to `0.0.52` for @petewarden (hope im helping and not skipping steps)
- align `moonshine_voice.__version__` with the packaged release version and add it to `scripts/update-version.sh` so future bumps stay consistent

## How it works

PyPI `moonshine-voice==0.0.49` shipped a Python binding that was out of sync with the compiled C ABI for `transcript_line_t`.

- the binary struct was 80 bytes because it included `words` and `word_count`
- the published Python ctypes struct was still 64 bytes

That mismatch caused Python to walk transcript line arrays with the wrong stride, which led to SIGSEGV on multi-line transcription output.

The struct definitions on `main` are already correct. This change adds a permanent guard so future packaging drift fails immediately at import time with a clear error.

## API changes

- no public API surface changed
- `moonshine_voice` now raises `ImportError` at import time if the Python ctypes binding drifts from the compiled C ABI
- Python runtime version reporting is aligned to `0.0.52`

## Test plan

- [x] `python3 -m py_compile python/src/moonshine_voice/moonshine_api.py python/src/moonshine_voice/__init__.py`
- [x] Validate ctypes sizes directly:
  - `TranscriptWordC = 24`
  - `TranscriptLineC = 80`
  - `TranscriptC = 16`
- [x] Verify the import guard still runs under `python3 -O`
- [x] Build the native library with `cmake -S core -B core/build-ninja -G Ninja && cmake --build core/build-ninja`
- [x] Run representative native tests from `test-assets/`:
  - `bin-tokenizer-test`
  - `debug-utils-test`
  - `string-utils-test`
  - `ort-utils-test`
  - `moonshine-c-api-test`
  - `transcriber-test`

## Files changed

| File | Change |
|------|--------|
| `python/src/moonshine_voice/moonshine_api.py` | add import-time ctypes struct size guards |
| `python/src/moonshine_voice/__init__.py` | align `__version__` to `0.0.52` |
| `python/pyproject.toml` | bump Python package version to `0.0.52` |
| `python/setup.py` | bump Python package version to `0.0.52` |
| `core/CMakeLists.txt` | bump core release version to `0.0.52` |
| `build.gradle.kts` | bump Android publish coordinates to `0.0.52` |
| `scripts/update-version.sh` | include `python/src/moonshine_voice/__init__.py` in managed version files |
| `scripts/publish-binary.sh` | bump release version to `0.0.52` |
| `scripts/publish-binary.bat` | bump release version to `0.0.52` |
| `scripts/publish-swift.sh` | bump release version to `0.0.52` |
| `README.md` | update Android example version to `0.0.52` |
| `examples/android/Transcriber/gradle/libs.versions.toml` | bump example dependency to `0.0.52` |
| `examples/macos/BasicTranscription/Package.swift` | bump example Swift package dependency to `0.0.52` |
| `examples/macos/MicTranscription/Package.swift` | bump example Swift package dependency to `0.0.52` |
| `examples/macos/BasicTranscription/BasicTranscription.xcodeproj/project.pbxproj` | bump example Swift package minimum version to `0.0.52` |
| `examples/macos/MicTranscription/MicTranscription.xcodeproj/project.pbxproj` | bump example Swift package minimum version to `0.0.52` |
| `examples/ios/Transcriber/Transcriber.xcodeproj/project.pbxproj` | bump example Swift package minimum version to `0.0.52` |

## References

- Fixes #158
