### PR TITLE
Reduce streaming transcription memory by not retaining completed VAD segment PCM

### DIFF
--- a/core/transcriber.cpp
+++ b/core/transcriber.cpp
@@ -452,10 +452,27 @@ void Transcriber::transcribe_stream(int32_t stream_id, uint32_t flags,
     std::lock_guard<std::mutex> lock(stream->vad_mutex);
     stream->vad->process_audio(audio_data, (int32_t)audio_length,
                                INTERNAL_SAMPLE_RATE);
-    segments = *(stream->vad->get_segments());
+    const std::vector<VoiceActivitySegment> *vad_segments =
+        stream->vad->get_segments();
+    segments.reserve(vad_segments->size());
+    for (const VoiceActivitySegment &segment : *vad_segments) {
+      VoiceActivitySegment segment_copy;
+      segment_copy.start_time = segment.start_time;
+      segment_copy.end_time = segment.end_time;
+      segment_copy.is_complete = segment.is_complete;
+      segment_copy.just_updated = segment.just_updated;
+      if (segment.just_updated) {
+        segment_copy.audio_data = segment.audio_data;
+      }
+      segments.push_back(std::move(segment_copy));
+    }
   }
   stream->clear_new_audio_buffer();
   this->update_transcript_from_segments(segments, stream, flags, out_transcript);
+  {
+    std::lock_guard<std::mutex> lock(stream->vad_mutex);
+    stream->vad->clear_completed_segment_audio_data();
+  }
 }
 
 std::string Transcriber::transcript_to_string(

--- a/core/transcriber.cpp
+++ b/core/transcriber.cpp
@@ -469,7 +469,7 @@ void Transcriber::transcribe_stream(int32_t stream_id, uint32_t flags,
   }
   stream->clear_new_audio_buffer();
   this->update_transcript_from_segments(segments, stream, flags, out_transcript);
-  {
+  if (!this->options.return_audio_data) {
     std::lock_guard<std::mutex> lock(stream->vad_mutex);
     stream->vad->clear_completed_segment_audio_data();
   }

--- a/core/voice-activity-detector.cpp
+++ b/core/voice-activity-detector.cpp
@@ -96,6 +96,14 @@ void VoiceActivityDetector::process_audio(const float *audio_data,
   processing_remainder_audio_buffer = processing_buffer;
 }
 
+void VoiceActivityDetector::clear_completed_segment_audio_data() {
+  for (VoiceActivitySegment &segment : segments) {
+    if (segment.is_complete && !segment.audio_data.empty()) {
+      std::vector<float>().swap(segment.audio_data);
+    }
+  }
+}
+
 void VoiceActivityDetector::process_audio_chunk(const float *audio_data,
                                                 size_t audio_data_size) {
   assert(audio_data_size == (size_t)(hop_size));

--- a/core/voice-activity-detector.h
+++ b/core/voice-activity-detector.h
@@ -56,6 +56,7 @@ class VoiceActivityDetector {
   const std::vector<VoiceActivitySegment> *get_segments() const {
     return &segments;
   }
+  void clear_completed_segment_audio_data();
   std::string to_string() const;
 
  private:


### PR DESCRIPTION
Hi Moonshine maintainers — first, thank you for building and sharing this library.

I’m building a cross-platform React Native/Web moonshine wrapper, `@siteed/moonshine.rn`, with validation paths for Web, Android, and iOS.

- Npm: https://www.npmjs.com/package/@siteed/moonshine.rn
- Playground: https://deeeed.github.io/audiolab/playground/
- Moonshine RN wrapper: https://github.com/deeeed/audiolab/tree/feat/audio-studio-stream-decode/packages/moonshine.rn

While validating long-form mobile transcription through that wrapper, I hit a native-memory issue in Moonshine’s streaming path. This PR is a small upstream fix for that issue: avoid retaining/copying PCM for VAD segments that have already been transcribed.

## What changed

- Only copy `audio_data` for VAD segments marked `just_updated`.
- Clear `audio_data` for completed VAD segments after transcript update.
- Preserve active/incomplete segment audio so streaming/finalization behavior remains intact.

<details>
<summary>Why this matters</summary>

In the current streaming path, `Transcriber::transcribe_stream()` copies the full `VoiceActivityDetector::segments` vector on every transcription update. Since each `VoiceActivitySegment` owns `audio_data`, very long streams repeatedly copy historical audio and keep completed segment PCM alive until the stream is destroyed.

The downstream React Native wrapper exposed this because it runs Moonshine streaming transcription on long compressed audio files with progress/memory telemetry.

</details>

<details open>
<summary>Validation summary</summary>

Validated from `audiolab`, which builds Moonshine from source for the React Native wrapper and streams a ~100-minute Opus fixture through `moonshine-small-streaming-en`.

Downstream repo: https://github.com/deeeed/audiolab  
Benchmark doc: `packages/audio-studio/docs/LONG_AUDIO_BENCHMARK.md`  
Harness: `packages/audio-studio/scripts/validate-stream-long.mjs`

| Platform | Device/runtime | Audio | Model | Result | Chunks | Transcript | Wall time | Memory |
| --- | --- | ---: | --- | --- | ---: | ---: | ---: | --- |
| Android | physical Pixel 6a, mid/low-range device | 100m24s Opus | `moonshine-small-streaming-en` | PASS, progress `1.0` | 24,098 | 50,176 chars / 1,707 lines | 117m22s | peak 1,245,778 KB PSS / 690,887 KB native heap; final 654,312 KB PSS / 233,145 KB native heap |
| iOS | physical iPhone 12, mid/low-range device | 102m56s Opus | `moonshine-small-streaming-en` | PASS, progress `1.0` | 24,098 | 50,975 chars / 1,697 lines | 91m25s | iOS memory telemetry not wired yet |
| iOS | simulator | 102m56s Opus | `moonshine-small-streaming-en` | PASS, progress `1.0` | 24,098 | 50,975 chars / 1,697 lines | 28m30s | simulator-only timing; not used as device benchmark |

Before this fix, the same Android long run showed unbounded native heap growth and failed the downstream memory budget around 31.7% of the file.

</details>
