### PR TITLE
Adding support for 32bit "Android  TV armeabi-v7a" targets

### DIFF
--- a/core/ort-utils/ort-utils.cpp
+++ b/core/ort-utils/ort-utils.cpp
@@ -1,6 +1,10 @@
 #include "ort-utils.h"
 
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
+#include <memory>
+#include <mutex>
 
 #ifndef _WIN32
 #include <fcntl.h>
@@ -83,8 +87,36 @@ int ort_session_from_memory(const OrtApi *ort_api, OrtEnv *env,
                             OrtSession **session) {
   RETURN_ON_NULL(ort_api);
   RETURN_ON_NULL(data);
+  // CreateSessionFromArray parses the .ort flatbuffer in place and performs
+  // aligned (e.g. 64-bit) loads. Buffers backed by file/mmap or heap vectors
+  // are sufficiently aligned, but the baked-in model data arrays (static
+  // const uint8_t[]) are only 1-byte aligned, which faults with SIGBUS
+  // (BUS_ADRALN) on 32-bit ARM (armeabi-v7a). When the source pointer is not
+  // 64-byte aligned, copy it into an aligned buffer that outlives the session
+  // (ORT may reference the bytes directly for the session's lifetime).
+  const uint8_t *aligned_data = data;
+  // Match the page alignment that the file/mmap load path (ort_session_from_path)
+  // produces; 64-byte alignment is not sufficient to avoid the SIGBUS on ARM32.
+  const size_t kAlign = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+  if ((reinterpret_cast<uintptr_t>(data) % kAlign) != 0) {
+    static std::mutex aligned_store_mutex;
+    static std::vector<std::unique_ptr<uint8_t, void (*)(void *)>> aligned_store;
+    const size_t padded = (data_size + (kAlign - 1)) & ~(kAlign - 1);
+    void *buf = nullptr;
+    if (posix_memalign(&buf, kAlign, padded == 0 ? kAlign : padded) != 0 ||
+        buf == nullptr) {
+      LOGF("%s", "Failed to allocate aligned buffer for in-memory ORT model");
+      return -1;
+    }
+    std::memcpy(buf, data, data_size);
+    {
+      std::lock_guard<std::mutex> lock(aligned_store_mutex);
+      aligned_store.emplace_back(static_cast<uint8_t *>(buf), std::free);
+    }
+    aligned_data = static_cast<const uint8_t *>(buf);
+  }
   RETURN_ON_ORT_ERROR(
-      ort_api, ort_api->CreateSessionFromArray(env, data, data_size,
+      ort_api, ort_api->CreateSessionFromArray(env, aligned_data, data_size,
                                                session_options, session));
   return 0;
 }

--- a/docs/android-32bit-armeabi-v7a.md
+++ b/docs/android-32bit-armeabi-v7a.md
@@ -1,0 +1,99 @@
+# Building the Android library for 32-bit ARM (`armeabi-v7a`)
+
+By default the Android library is built for `arm64-v8a` only. This guide
+explains how to also build it for 32-bit ARM (`armeabi-v7a`), e.g. for older
+phones or 32-bit Android TV boxes running a 32-bit image on an ARMv8 SoC.
+
+## Background: the SIGBUS fix
+
+Creating a transcriber on `armeabi-v7a` used to crash with
+`SIGBUS / BUS_ADRALN` inside `CreateSessionFromArray`, before transcription
+started. The auxiliary models are baked into the library as
+`static const uint8_t[]` arrays (1-byte aligned); ORT parses the `.ort`
+flatbuffer in place using aligned (e.g. 64-bit) loads, which fault on ARM32.
+
+This is already fixed in source: `ort_session_from_memory()` in
+[`core/ort-utils/ort-utils.cpp`](../core/ort-utils/ort-utils.cpp) copies any
+non-page-aligned buffer into a page-aligned, lifetime-persistent buffer before
+handing it to ORT. The fix is a no-op on `arm64-v8a`/x86 and for file/mmap
+loaded models, so nothing below changes those builds.
+
+## Steps
+
+### 1. Enable the ABI in `build.gradle.kts`
+
+Add `armeabi-v7a` to the ABI filter:
+
+```kotlin
+android {
+    defaultConfig {
+        ndk {
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a")
+        }
+    }
+}
+```
+
+### 2. Provide a 32-bit `libonnxruntime.so`
+
+The repo only ships the `arm64-v8a` ONNX Runtime. Extract the 32-bit one from
+the matching ONNX Runtime Android AAR
+(`com.microsoft.onnxruntime:onnxruntime-android:1.23.2`) — the file is at
+`jni/armeabi-v7a/libonnxruntime.so` inside the AAR (an AAR is a zip) — and copy
+it to **both** locations:
+
+- `core/third-party/onnxruntime/lib/android/armeabi-v7a/libonnxruntime.so`
+  (used when CMake links the native code)
+- `src/main/jniLibs/armeabi-v7a/libonnxruntime.so`
+  (packaged into the APK/AAR at runtime)
+
+Verify it is the right binary:
+
+```sh
+file core/third-party/onnxruntime/lib/android/armeabi-v7a/libonnxruntime.so
+# => ELF 32-bit LSB shared object, ARM, EABI5 ...
+
+nm -D core/third-party/onnxruntime/lib/android/armeabi-v7a/libonnxruntime.so \
+    | grep OrtGetApiBase
+# => exports OrtGetApiBase
+```
+
+Keep the ONNX Runtime version in step 2 in sync with the `arm64-v8a` build so
+both ABIs use the same runtime.
+
+### 3. Ship the Silero VAD as `.ort` (not `.onnx`)
+
+The bundled Silero VAD is an `.onnx` protobuf. ORT 1.23.2 cannot load it on
+ARM32 even when the buffer is page-aligned (protobuf stores float initializers
+at arbitrary sub-4-byte offsets, which ORT's ARM32 build reads with
+alignment-sensitive instructions). Every `.ort` flatbuffer model loads fine, so
+convert the VAD to `.ort` and re-bake it:
+
+```sh
+python -m onnxruntime.tools.convert_onnx_models_to_ort silero_vad.onnx \
+    --optimization_style Fixed --output_dir out
+# regenerate core/silero-vad-model-data.h from out/silero_vad.ort,
+# keeping the symbol names (silero_vad_onnx / silero_vad_onnx_len)
+```
+
+`CreateSessionFromArray` auto-detects the format, so no loader changes are
+needed — only the baked bytes. Declaring the baked array `alignas(64)` is good
+hygiene on top of the runtime fix in step 1.
+
+### 4. Build
+
+```sh
+./gradlew :assembleRelease
+```
+
+The output AAR now contains native libraries for both `arm64-v8a` and
+`armeabi-v7a`.
+
+## Notes
+
+- Real `.ort` models and `*-model-data.cpp` are stored with Git LFS. In a fresh
+  checkout run `git lfs install --local && git lfs pull` so they are
+  materialized (otherwise they are pointer stubs).
+- Speaker diarization loads an additional baked model. The alignment fix in
+  step 1 covers it too; if you don't need diarization you can disable it
+  (`identify_speakers=false`) to skip that model load entirely.


### PR DESCRIPTION
Hi,

This is a very specific issue that solves a very specific problem with a particular board running Android TV 14 as 32-bit `armeabi-v7a`.

I know Android 14 is already quite old, but it is the last version that still supports the NPU on this board. I also understand that using a 32-bit build throws away many of the advantages that NEON SIMD can provide. I was not able to get Moonshine running well on this chip using SIMD.

Also, I understand that 32-bit-only Android builds are not really the preferred or future-proof path anymore, especially for Google Play distribution, where apps with native code generally need to provide 64-bit support as well. However, this board is limited to a 32-bit userspace, so this fix is mainly useful for this specific class of Android TV devices.

With a little help from our AI friends, I was at least able to get Moonshine running on the CPU.

Now I am trying to get Moonshine running on the NPU using NNAPI.

I hope this fix can be useful in general. If not, feel free to close the issue with a short note.

I would appreciate any feedback.

[1]: https://developer.android.com/google/play/requirements/64-bit?utm_source=chatgpt.com "Support 64-bit architectures | Compatibility"
[2]: https://android-developers.googleblog.com/2025/08/64-bit-app-compatibility-for-google-tv-android-tv.html?utm_source=chatgpt.com "64-bit app compatibility for Google TV and Android TV"