### PR TITLE
Fix moonshine_free_stream return type and missing cstdint include

### DIFF
--- a/core/moonshine-c-api.cpp
+++ b/core/moonshine-c-api.cpp
@@ -332,7 +332,7 @@ int32_t moonshine_create_stream(int32_t transcriber_handle, uint32_t flags) {
   }
 }
 
-int moonshine_free_stream(int32_t transcriber_handle, int32_t stream_handle) {
+int32_t moonshine_free_stream(int32_t transcriber_handle, int32_t stream_handle) {
   if (log_api_calls) {
     LOGF("moonshine_free_stream(transcriber_handle=%d, stream_handle=%d)",
          transcriber_handle, stream_handle);

--- a/core/moonshine-utils/string-utils.h
+++ b/core/moonshine-utils/string-utils.h
@@ -1,6 +1,7 @@
 #ifndef STRING_UTILS_H
 #define STRING_UTILS_H
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
## Summary

This PR cherry-picks the substantive fixes from #170, without the redundant per-function `extern "C"` annotations on C API implementations (those are already covered by the `extern "C" { ... }` block in `moonshine-c-api.h`).

- Fix `moonshine_free_stream` return type from `int` to `int32_t` to match the header declaration
- Add `#include <cstdint>` to `string-utils.h` so `int32_t`/`int64_t` are defined when the header is included directly

## Related

Supersedes the functional parts of #170. The `extern "C"` changes in that PR are not needed for linkage when implementations follow declarations from the header.

## Test plan

- [x] Core library builds successfully
- [x] C API consumers link against `moonshine_free_stream` without signature mismatch


Made with [Cursor](https://cursor.com)