### PR TITLE
Fix/spanish g2p rhotics and glides

### DIFF
--- a/core/moonshine-tts/src/lang-specific/spanish.cpp
+++ b/core/moonshine-tts/src/lang-specific/spanish.cpp
@@ -503,6 +503,7 @@ char32_t to_lower_cp(char32_t c) {
 
 std::string letters_to_ipa_no_stress(const std::u32string &syl_lower,
                                      const SpanishDialect &dialect,
+                                     const std::u32string &word_lower,
                                      size_t grapheme_offset) {
   const std::u32string &lw = syl_lower;
   size_t i = 0;
@@ -665,16 +666,12 @@ std::string letters_to_ipa_no_stress(const std::u32string &syl_lower,
     }
 
     if (ch == U'r') {
-      const bool at_word_start = (i == 0);
-      const bool after_lns = i > 0 && (lw[i - 1] == U'l' || lw[i - 1] == U'n' ||
-                                       lw[i - 1] == U's');
-      if (at_word_start || after_lns) {
-        out.push_back(dialect.trill_ipa);
-      } else if (prev_phoneme_was_vowel(out) && peek_vowel(i + 1)) {
-        out.push_back(dialect.tap_ipa);
-      } else {
-        out.push_back(dialect.tap_ipa);
-      }
+      const size_t abs_pos = grapheme_offset + i;
+      const char32_t prev = abs_pos > 0 ? word_lower[abs_pos - 1] : U'\0';
+      const bool at_word_start = (abs_pos == 0);
+      const bool after_lns = (prev == U'l' || prev == U'n' || prev == U's');
+      out.push_back((at_word_start || after_lns) ? dialect.trill_ipa
+                                                 : dialect.tap_ipa);
       ++i;
       continue;
     }
@@ -979,11 +976,17 @@ std::string SpanishRuleG2p::word_to_ipa(const std::string &word) const {
   const size_t stress_idx =
       with_stress_ ? default_stressed_syllable_index_v2(clean_syllable_word(lw))
                    : static_cast<size_t>(-1);
+  std::vector<std::u32string> syl_u32;
+  std::u32string syl_word;
+  syl_u32.reserve(syl.size());
+  for (const auto &s : syl) {
+    syl_u32.push_back(spanish_unicode::utf8_to_utf32(s));
+    syl_word += syl_u32.back();
+  }
   size_t offset = 0;
   std::vector<std::string> parts;
-  for (const auto &s : syl) {
-    const std::u32string su = spanish_unicode::utf8_to_utf32(s);
-    parts.push_back(letters_to_ipa_no_stress(su, dialect_, offset));
+  for (const auto &su : syl_u32) {
+    parts.push_back(letters_to_ipa_no_stress(su, dialect_, syl_word, offset));
     offset += su.size();
   }
   if (with_stress_ && !parts.empty() && stress_idx < parts.size()) {

--- a/core/moonshine-tts/src/lang-specific/spanish.cpp
+++ b/core/moonshine-tts/src/lang-specific/spanish.cpp
@@ -6,7 +6,6 @@
 #include <regex>
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -382,7 +381,8 @@ std::string apply_narrow_intervocalic_obstruents(std::string ipa) {
     std::u32string u = spanish_unicode::utf8_to_utf32(ipa);
     bool changed = false;
     auto is_v = [](char32_t c) {
-      return c == U'a' || c == U'e' || c == U'i' || c == U'o' || c == U'u';
+      return c == U'a' || c == U'e' || c == U'i' || c == U'o' || c == U'u' ||
+             c == U'j' || c == U'w';
     };
     for (size_t i = 0; i < u.size(); ++i) {
       if (i == 0 || i + 1 >= u.size()) {
@@ -570,37 +570,26 @@ std::string letters_to_ipa_no_stress(const std::u32string &syl_lower,
       continue;
     }
 
-    if (ch == U'q' && i + 2 < n && lw[i + 1] == U'u' &&
-        (lw[i + 2] == U'e' || lw[i + 2] == U'i' || lw[i + 2] == U'é' ||
-         lw[i + 2] == U'í')) {
-      static const std::unordered_map<char32_t, const char *> vmap = {
-          {U'e', "e"}, {U'i', "i"}, {U'é', "e"}, {U'í', "i"}};
+    const bool front_after_u =
+        i + 2 < n && (lw[i + 2] == U'e' || lw[i + 2] == U'i' ||
+                      lw[i + 2] == U'é' || lw[i + 2] == U'í');
+
+    if (ch == U'q' && front_after_u && lw[i + 1] == U'u') {
       out.emplace_back("k");
-      out.emplace_back(vmap.at(lw[i + 2]));
-      i += 3;
+      i += 2;
       continue;
     }
 
-    if (ch == U'g' && i + 2 < n && lw[i + 1] == U'ü' &&
-        (lw[i + 2] == U'e' || lw[i + 2] == U'i' || lw[i + 2] == U'é' ||
-         lw[i + 2] == U'í')) {
-      static const std::unordered_map<char32_t, const char *> vmap = {
-          {U'e', "e"}, {U'i', "i"}, {U'é', "e"}, {U'í', "i"}};
+    if (ch == U'g' && front_after_u && lw[i + 1] == U'ü') {
       out.emplace_back("\xc9\xa1");  // ɡ
       out.emplace_back("w");
-      out.emplace_back(vmap.at(lw[i + 2]));
-      i += 3;
+      i += 2;
       continue;
     }
 
-    if (ch == U'g' && i + 2 < n && lw[i + 1] == U'u' &&
-        (lw[i + 2] == U'e' || lw[i + 2] == U'i' || lw[i + 2] == U'é' ||
-         lw[i + 2] == U'í')) {
-      static const std::unordered_map<char32_t, const char *> vmap = {
-          {U'e', "e"}, {U'i', "i"}, {U'é', "e"}, {U'í', "i"}};
+    if (ch == U'g' && front_after_u && lw[i + 1] == U'u') {
       out.emplace_back("\xc9\xa1");
-      out.emplace_back(vmap.at(lw[i + 2]));
-      i += 3;
+      i += 2;
       continue;
     }
 
@@ -609,19 +598,6 @@ std::string letters_to_ipa_no_stress(const std::u32string &syl_lower,
          lw[i + 1] == U'í')) {
       out.push_back(dialect.voiceless_velar_fricative);
       ++i;
-      continue;
-    }
-
-    if (ch == U'c' && i + 3 < n && lw.substr(i, 4) == U"ción") {
-      out.push_back(dialect.ce_ci_z_ipa);
-      out.emplace_back("jon");
-      i += 4;
-      continue;
-    }
-    if (ch == U'c' && i + 2 < n && lw.substr(i, 3) == U"ció") {
-      out.push_back(dialect.ce_ci_z_ipa);
-      out.emplace_back("jo");
-      i += 3;
       continue;
     }
 
@@ -672,6 +648,13 @@ std::string letters_to_ipa_no_stress(const std::u32string &syl_lower,
       const bool after_lns = (prev == U'l' || prev == U'n' || prev == U's');
       out.push_back((at_word_start || after_lns) ? dialect.trill_ipa
                                                  : dialect.tap_ipa);
+      ++i;
+      continue;
+    }
+
+    if ((ch == U'i' || ch == U'u') && i + 1 < n && is_vowel_ch(lw[i + 1]) &&
+        !should_hiatus(ch, lw[i + 1])) {
+      out.emplace_back(ch == U'i' ? "j" : "w");
       ++i;
       continue;
     }

--- a/core/moonshine-tts/tests/data/es_mx/rule_g2p_en_1891.txt
+++ b/core/moonshine-tts/tests/data/es_mx/rule_g2p_en_1891.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9dce0573dc57fcb4dea1994f98a6cf0f74206d8112056447773aae018acab9f4
+oid sha256:676f3605fd3305968c24d3578735f563bc4f3eb9b9f918472a81c053ba8303ea
 size 46

--- a/core/moonshine-tts/tests/spanish-rule-g2p-test.cpp
+++ b/core/moonshine-tts/tests/spanish-rule-g2p-test.cpp
@@ -61,6 +61,65 @@ TEST_CASE("spanish: tap and trill are distinguished in every context") {
   }
 }
 
+TEST_CASE("spanish: rising diphthongs use glides and stress the nucleus") {
+  const std::vector<std::pair<std::string, std::string>> cases = {
+      {"sonrió", "sonrjˈo"},
+      {"sonrío", "sonrˈio"},
+      {"salió", "saljˈo"},
+      {"comió", "komjˈo"},
+      {"cambio", "kˈambjo"},
+      {"serio", "sˈeɾjo"},
+      {"radio", "rˈaðjo"},
+      {"patio", "pˈatjo"},
+      {"limpio", "lˈimpjo"},
+      {"cuando", "kwˈando"},
+      {"pueblo", "pwˈeblo"},
+      {"bueno", "bwˈeno"},
+      {"fuerte", "fwˈeɾte"},
+      {"agua", "ˈaɣwa"},
+      {"cuota", "kwˈota"},
+      {"cuidar", "kwidˈaɾ"},
+      {"antiguo", "antˈiɣwo"},
+      {"viuda", "bjˈuða"},
+      {"hielo", "jˈelo"},
+      {"huevo", "wˈeβo"},
+      {"efectuará", "efektwaɾˈa"},
+      {"continuó", "kontinwˈo"},
+      {"río", "rˈio"},
+      {"mío", "mˈio"},
+      {"día", "dˈia"},
+      {"país", "paˈis"},
+      {"queso", "kˈeso"},
+      {"guerra", "ɡˈera"},
+      {"guitarra", "ɡitˈara"},
+      {"sigue", "sˈiɣe"},
+      {"pingüino", "pinɡwˈino"},
+      {"averigüe", "aβeɾˈiɣwe"},
+  };
+  for (const char* id : {"es-ES", "es-MX"}) {
+    const auto dialect = moonshine_tts::spanish_dialect_from_cli_id(id);
+    for (const auto& [word, expected] : cases) {
+      INFO(id << " " << word);
+      CHECK(moonshine_tts::spanish_text_to_ipa(word, dialect) == expected);
+    }
+  }
+}
+
+TEST_CASE("spanish: seseo and distincion keep glides in -cion words") {
+  const auto es = moonshine_tts::spanish_dialect_from_cli_id("es-ES");
+  const auto mx = moonshine_tts::spanish_dialect_from_cli_id("es-MX");
+  CHECK(moonshine_tts::spanish_text_to_ipa("nación", es) == "naθjˈon");
+  CHECK(moonshine_tts::spanish_text_to_ipa("nación", mx) == "nasjˈon");
+  CHECK(moonshine_tts::spanish_text_to_ipa("novecientos", es) ==
+        "noβeθjˈentos");
+  CHECK(moonshine_tts::spanish_text_to_ipa("novecientos", mx) ==
+        "noβesjˈentos");
+  CHECK(moonshine_tts::spanish_text_to_ipa("cincuenta", es) == "θinkwˈenta");
+  CHECK(moonshine_tts::spanish_text_to_ipa("cincuenta", mx) == "sinkwˈenta");
+  CHECK(moonshine_tts::spanish_text_to_ipa("ciudad", es) == "θjudˈad");
+  CHECK(moonshine_tts::spanish_text_to_ipa("ciudad", mx) == "sjudˈad");
+}
+
 TEST_CASE("spanish: En 1891 matches reference IPA when golden exists") {
   const auto repo = r::repo_root_from_tests_cpp(__FILE__);
   const std::filesystem::path golden =

--- a/core/moonshine-tts/tests/spanish-rule-g2p-test.cpp
+++ b/core/moonshine-tts/tests/spanish-rule-g2p-test.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "rule-g2p-test-support.h"
@@ -31,6 +32,34 @@ void check_wiki_parity(const std::filesystem::path& wiki,
 }
 
 }  // namespace
+
+TEST_CASE("spanish: tap and trill are distinguished in every context") {
+  const std::vector<std::pair<std::string, std::string>> cases = {
+      {"pero", "pˈeɾo"},
+      {"perro", "pˈero"},
+      {"caro", "kˈaɾo"},
+      {"carro", "kˈaro"},
+      {"oro", "ˈoɾo"},
+      {"para", "pˈaɾa"},
+      {"honra", "ˈonra"},
+      {"Israel", "isrˈael"},
+      {"enredo", "enrˈeðo"},
+      {"sonrisa", "sonrˈisa"},
+      {"alrededor", "alreðedˈoɾ"},
+      {"rosa", "rˈosa"},
+      {"por", "pˈoɾ"},
+      {"arte", "ˈaɾte"},
+      {"tren", "tɾˈen"},
+      {"tres", "tɾˈes"},
+  };
+  for (const char* id : {"es-ES", "es-MX"}) {
+    const auto dialect = moonshine_tts::spanish_dialect_from_cli_id(id);
+    for (const auto& [word, expected] : cases) {
+      INFO(id << " " << word);
+      CHECK(moonshine_tts::spanish_text_to_ipa(word, dialect) == expected);
+    }
+  }
+}
 
 TEST_CASE("spanish: En 1891 matches reference IPA when golden exists") {
   const auto repo = r::repo_root_from_tests_cpp(__FILE__);


### PR DESCRIPTION
## What this changes

This fixes two bugs in the Spanish G2P rules.

The first one affected the `r`/`rr` contrast. `pero` and `perro` both came out
as `pˈero` because the code checked `i == 0` to detect the start of a word, but
`i` is the syllable index. The same issue meant the trill wasn't triggered after
`l`, `n`, or `s`, so words like `honra`, `Israel`, and `alrededor` were also
wrong. The fix is to pass the word context into the syllable loop instead of
inferring it from the syllable index.

The second bug affected rising diphthongs. `sonrió` and `sonrío` both came out
as `sonrˈio` because the glide was emitted as a full vowel, so the stress mark
ended up on it. Non-hiatus `i`/`u` before another vowel are now emitted as
`j`/`w`, which also fixes forms like `pwˈeblo`, `kwˈando`, and `ˈaɣwa`.

`rule_g2p_en_1891.txt` was regenerated (`otʃosˈientos` → `otʃosjˈentos`). Since
it's tracked with LFS, the actual diff isn't visible.

The two `rule_g2p_wiki_100.txt` files are still stale. I couldn't regenerate
them because `data/es_*/wiki-text.txt` isn't available, which is also why the
parity tests continue to skip.

## How it was tested

- Full test suite: 32/32 passing.
- Expanded the Spanish G2P test from 5 to 107 assertions, covering both es-ES
  and es-MX.
- Compared G2P output before and after on 91 representative words: 29 changed,
  62 unchanged.