### PR TITLE
docs: clarify that MOONSHINE_MODEL_ARCH_BASE_STREAMING is not currently in model catalog

### DIFF
--- a/core/moonshine-c-api.h
+++ b/core/moonshine-c-api.h
@@ -107,6 +107,8 @@ extern "C" {
 #define MOONSHINE_MODEL_ARCH_TINY (0)
 #define MOONSHINE_MODEL_ARCH_BASE (1)
 #define MOONSHINE_MODEL_ARCH_TINY_STREAMING (2)
+/* Note: BASE_STREAMING is defined for future use but is not currently
+   published in the model catalog.                                           */
 #define MOONSHINE_MODEL_ARCH_BASE_STREAMING (3)
 #define MOONSHINE_MODEL_ARCH_SMALL_STREAMING (4)
 #define MOONSHINE_MODEL_ARCH_MEDIUM_STREAMING (5)
@@ -1046,7 +1048,8 @@ MOONSHINE_EXPORT int32_t moonshine_get_tts_voices(
    do are honored:
      - ``model_arch``: one of the MOONSHINE_MODEL_ARCH_* constants as a decimal
        string. When omitted, the default (first) model for the language is
-       used.
+       used. Note: MOONSHINE_MODEL_ARCH_BASE_STREAMING is defined but not
+       currently published in the model catalog.
      - ``word_timestamps`` (bool): when true, the optional attention decoder
        (``decoder_kv_with_attention.ort`` for streaming, or
        ``decoder_with_attention.ort`` for non-streaming) is included for


### PR DESCRIPTION
## Description

Clarifies in `core/moonshine-c-api.h` that `MOONSHINE_MODEL_ARCH_BASE_STREAMING` (value `3`) is defined as a constant, but is not currently published in the model catalog for `moonshine_get_stt_dependencies`.

Closes #214.