### PR TITLE
Unmap the streaming decoder model files on destruction

### DIFF
--- a/core/moonshine-streaming-model.cpp
+++ b/core/moonshine-streaming-model.cpp
@@ -193,6 +193,14 @@ MoonshineStreamingModel::~MoonshineStreamingModel() {
   if (adapter_mmapped_data) {
     munmap(const_cast<char *>(adapter_mmapped_data), adapter_mmapped_data_size);
   }
+  if (cross_kv_mmapped_data) {
+    munmap(const_cast<char *>(cross_kv_mmapped_data),
+           cross_kv_mmapped_data_size);
+  }
+  if (decoder_kv_mmapped_data) {
+    munmap(const_cast<char *>(decoder_kv_mmapped_data),
+           decoder_kv_mmapped_data_size);
+  }
 #endif
 }
 
@@ -253,24 +261,18 @@ int MoonshineStreamingModel::load(const char *model_dir,
       append_path_component(model_dir, "decoder_kv.ort");
 
   // Load cross_kv (required)
-  {
-    const char *cross_kv_mmap = nullptr;
-    size_t cross_kv_mmap_size = 0;
-    RETURN_ON_ERROR(ort_session_from_path(
-        ort_api, ort_env, ort_session_options, cross_kv_path.c_str(),
-        &cross_kv_session, &cross_kv_mmap, &cross_kv_mmap_size));
-    RETURN_ON_NULL(cross_kv_session);
-  }
+  RETURN_ON_ERROR(ort_session_from_path(
+      ort_api, ort_env, ort_session_options, cross_kv_path.c_str(),
+      &cross_kv_session, &cross_kv_mmapped_data, &cross_kv_mmapped_data_size));
+  RETURN_ON_NULL(cross_kv_session);
 
   // Load decoder_kv (required)
-  {
-    const char *decoder_kv_mmap = nullptr;
-    size_t decoder_kv_mmap_size = 0;
-    RETURN_ON_ERROR(ort_session_from_path(
-        ort_api, ort_env, ort_session_options, decoder_kv_path.c_str(),
-        &decoder_kv_session, &decoder_kv_mmap, &decoder_kv_mmap_size));
-    RETURN_ON_NULL(decoder_kv_session);
-  }
+  RETURN_ON_ERROR(
+      ort_session_from_path(ort_api, ort_env, ort_session_options,
+                            decoder_kv_path.c_str(), &decoder_kv_session,
+                            &decoder_kv_mmapped_data,
+                            &decoder_kv_mmapped_data_size));
+  RETURN_ON_NULL(decoder_kv_session);
 
   // Load tokenizer
   tokenizer = new BinTokenizer(tokenizer_path);

--- a/core/moonshine-streaming-model.h
+++ b/core/moonshine-streaming-model.h
@@ -96,6 +96,10 @@ struct MoonshineStreamingModel {
   size_t encoder_mmapped_data_size = 0;
   const char *adapter_mmapped_data = nullptr;
   size_t adapter_mmapped_data_size = 0;
+  const char *cross_kv_mmapped_data = nullptr;
+  size_t cross_kv_mmapped_data_size = 0;
+  const char *decoder_kv_mmapped_data = nullptr;
+  size_t decoder_kv_mmapped_data_size = 0;
 
   std::string last_result;
 

--- a/core/transcriber.cpp
+++ b/core/transcriber.cpp
@@ -1,5 +1,9 @@
 #include "transcriber.h"
 
+#ifndef _WIN32
+#include <sys/mman.h>
+#endif
+
 #include <algorithm>
 #include <cassert>
 #include <cmath>
@@ -247,14 +251,24 @@ void Transcriber::load_from_files(const char *model_path, uint32_t model_arch) {
               this->streaming_model->decoder_kv_session);
         }
         this->streaming_model->decoder_kv_session = nullptr;
-        const char *dec_mmapped = nullptr;
-        size_t dec_mmapped_size = 0;
+#ifndef _WIN32
+        // The decoder this replaces was mapped by load(); release that mapping
+        // before the member takes ownership of the attention decoder's.
+        if (this->streaming_model->decoder_kv_mmapped_data) {
+          munmap(
+              const_cast<char *>(this->streaming_model->decoder_kv_mmapped_data),
+              this->streaming_model->decoder_kv_mmapped_data_size);
+          this->streaming_model->decoder_kv_mmapped_data = nullptr;
+          this->streaming_model->decoder_kv_mmapped_data_size = 0;
+        }
+#endif
         int32_t dec_err = ort_session_from_path(
             this->streaming_model->ort_api, this->streaming_model->ort_env,
             this->streaming_model->ort_session_options,
             decoder_attn_path.c_str(),
-            &this->streaming_model->decoder_kv_session, &dec_mmapped,
-            &dec_mmapped_size);
+            &this->streaming_model->decoder_kv_session,
+            &this->streaming_model->decoder_kv_mmapped_data,
+            &this->streaming_model->decoder_kv_mmapped_data_size);
         if (dec_err != 0) {
           LOGF("Warning: Failed to load decoder_kv_with_attention from %s\n",
                decoder_attn_path.c_str());


### PR DESCRIPTION
Fixes #216. Claude just created this, works for me.

---------------------------------

`MoonshineStreamingModel::load()` maps all five `.ort` files through `ort_session_from_path()`, which returns the mapping as out-params. Three of the five keep it:

```c
  RETURN_ON_ERROR(ort_session_from_path(
      ort_api, ort_env, ort_session_options, frontend_path.c_str(),
      &frontend_session, &frontend_mmapped_data, &frontend_mmapped_data_size));
```

`cross_kv` and `decoder_kv` passed locals scoped to a bare block instead, so the pointer and size were gone at the closing brace:

```c
  {
    const char *cross_kv_mmap = nullptr;
    size_t cross_kv_mmap_size = 0;
    RETURN_ON_ERROR(ort_session_from_path(..., &cross_kv_mmap, &cross_kv_mmap_size));
    RETURN_ON_NULL(cross_kv_session);
  }   // <- mapping is now unreachable
```

`moonshine-streaming-model.h` had no members for them, so the `munmap` block in `~MoonshineStreamingModel` had nothing to release for those two. It calls `ReleaseSession` on all five and unmaps three. That accounts for the reported ~83 MB per cycle exactly: `decoder_kv.ort` (77.7 MB) + `cross_kv.ort` (5.1 MB).

`transcriber.cpp` had the same shape on the word-timestamp path, which is the issue's ~160 MB case. Swapping in `decoder_kv_with_attention.ort` released the decoder session but passed locals for the replacement's mapping, and left the superseded `decoder_kv.ort` mapping in place.

Both sites now store into members alongside the other three, and the attention swap unmaps the decoder it replaces before taking ownership of the new one. No change to the in-memory loaders, which take caller-owned buffers and have nothing to unmap.

## Measurements

Linux x86_64, `small-streaming` English quantized, load / transcribe / free in a loop. Counting bytes still mapped per model file from `/proc/self/smaps` rather than inferring from RSS, which allocator reuse makes noisy:

| | mapped per cycle | retained after 6 |
| --- | --- | --- |
| before | +82.7 MB | +496.3 MB |
| after | +0.0 MB | +0.0 MB |

Leftovers before the change were `decoder_kv.ort` 543.6 MB and `cross_kv.ort` 35.4 MB. After it, nothing under the model directory stays mapped.

With `word_timestamps=true`, `decoder_kv_with_attention.ort` leaked a further +77.6 MB per cycle. That is also 0.0 now.

RSS still moves after the fix, in a band with no trend (187-264 MB over 20 cycles) rather than the ~84 MB per cycle of linear growth before. That residue is allocator arena reuse reaching steady state.

## Checks

- Every cycle returns identical transcript text before and after, which is what would break if a mapping were released while its session still read it.
- `transcriber-test` passes, including `transcribe-with-streaming` (13,925 assertions). The only failure in a full run is `test-identify-speakers`, which requires a `diarization` model directory I had not fetched.
- Untested on Windows. `ort_session_from_path()` sets the out-params to `nullptr` there and both new `munmap` calls sit inside the existing `#ifndef _WIN32` guards, so that path is unchanged.

## Notes

One thing worth a maintainer's judgement, deliberately not in this PR: the streaming model never sets `session.use_ort_model_bytes_directly` (unlike `moonshine-model.cpp:114`), so ORT copies the bytes and none of these five mappings is read after `CreateSessionFromArray` returns. They could be unmapped immediately at load, which would also release the ~150 MB the other three hold for each live transcriber. This PR keeps the file's existing lifetime idiom instead.