### PR TITLE
fix: pin HF models to last monolithic commit before TTS split 2 days ago

### DIFF
--- a/scripts/fetch-voice-assets.sh
+++ b/scripts/fetch-voice-assets.sh
@@ -136,7 +136,7 @@ fetch_tts_via_hf() {
   # Download only the tts/ tree, then flatten into data/ (HF paths are tts/<key>).
   local staging
   staging="$(mktemp -d "${TMPDIR:-/tmp}/moonshine-tts-hf.XXXXXX")"
-  if ! hf download "${HF_REPO}" --include "tts/**" --local-dir "${staging}"; then
+  if ! hf download "${HF_REPO}" --revision "35d84fc0eb2d7451da9973c990e8a77066abb105" --include "tts/**" --local-dir "${staging}"; then
     rm -rf "${staging}"
     return 1
   fi
@@ -193,7 +193,7 @@ fetch_tts_via_cdn_inventory() {
   local tsv
   tsv="$(mktemp)"
   if ! curl -fL -o "${tsv}" \
-    "https://huggingface.co/${HF_REPO}/resolve/main/FILES.tsv"; then
+    "https://huggingface.co/${HF_REPO}/resolve/35d84fc0eb2d7451da9973c990e8a77066abb105/FILES.tsv"; then
     rm -f "${tsv}"
     return 1
   fi


### PR DESCRIPTION
## What this changes
The recent HF assets update split the TTS models into multiple stages (e.g., `.generator`/`.upstream` for Piper and `decoder`/`prosody` for Kokoro). 

However, the C++ engine is still hardcoded to expect the monolithic models. This asset mismatch currently causes all C++ TTS executables to crash on initialization (throwing `Invalid input name: input` or `cannot open kokoro/model.ort`).

This PR temporarily pins `scripts/fetch-voice-assets.sh` to the last monolithic commit (`35d84fc0`) on the HF repo. This ensures the C++ executables can build and run  successfully out of the box until the C++ bindings are refactored to support the split graphs by the devs

## How it was tested
- Cleared the local model cache and ran `./scripts/fetch-voice-assets.sh tts`.
- Verified that the script correctly downloads the monolithic `kokoro/model.ort` and legacy Piper models instead of the new split models.
- Compiled `examples/c++/text-to-speech.cpp` and successfully ran `./tts -v piper_en_US-lessac-medium` and `./tts -v kokoro_af_heart` without the ONNX loader crashing.
