### PR TITLE
Fix use-after-free race in transcriber_map accessors

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - RP2350 firmware links on Pico SDK versions that pass `-nostartfiles` (undefined `__dso_handle` from libstdc++, GitHub issue #204).
+- Android crash when `close()` raced an in-flight transcription on the background thread (GitHub issue #223).
 
 ## [0.1.5]
 

--- a/core/moonshine-c-api-test.cpp
+++ b/core/moonshine-c-api-test.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -9,6 +11,7 @@
 #include <fstream>
 #include <optional>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -818,6 +821,55 @@ TEST_CASE("moonshine-test-v2") {
     std::free(audio);
     moonshine_free_tts_synthesizer(h);
   }
+}
+
+TEST_CASE("moonshine-free-transcriber-races-in-flight-stream-call") {
+  // GitHub issue #223: moonshine_free_transcriber() used to delete the
+  // Transcriber (and its member mutexes) while another thread's unlocked
+  // read of transcriber_map was still dereferencing it, aborting with
+  // "FORTIFY: pthread_mutex_lock called on a destroyed mutex" inside
+  // Transcriber::decode_full, reached via transcribe_stream. Drive a stream
+  // from a background thread while the main thread frees the transcriber
+  // mid-flight; every call must resolve its own reference under
+  // transcriber_map_mutex instead of racing the free.
+  std::string root_model_path = "tiny-en";
+  REQUIRE(std::filesystem::exists(root_model_path));
+  int32_t transcriber_handle = moonshine_load_transcriber_from_files(
+      root_model_path.c_str(), MOONSHINE_MODEL_ARCH_TINY, nullptr, 0,
+      MOONSHINE_HEADER_VERSION);
+  REQUIRE(transcriber_handle >= 0);
+
+  int32_t stream_id = moonshine_create_stream(transcriber_handle, 0);
+  REQUIRE(stream_id >= 0);
+  REQUIRE(moonshine_start_stream(transcriber_handle, stream_id) ==
+          MOONSHINE_ERROR_NONE);
+
+  const std::vector<float> silence(1600, 0.0f);  // 100ms at 16kHz.
+  std::atomic<bool> stop_streaming{false};
+  std::thread streamer([&]() {
+    while (!stop_streaming.load()) {
+      moonshine_transcribe_add_audio_to_stream(transcriber_handle, stream_id,
+                                               silence.data(), silence.size(),
+                                               16000, 0);
+      struct transcript_t* transcript = nullptr;
+      moonshine_transcribe_stream(transcriber_handle, stream_id, 0,
+                                  &transcript);
+    }
+  });
+
+  // Give the streamer thread a head start so the free below lands in the
+  // middle of its loop rather than before it begins.
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  moonshine_free_transcriber(transcriber_handle);
+  stop_streaming.store(true);
+  streamer.join();
+
+  // The handle is gone: every accessor must report it as invalid rather than
+  // touching freed memory.
+  struct transcript_t* transcript = nullptr;
+  CHECK(moonshine_transcribe_stream(transcriber_handle, stream_id, 0,
+                                    &transcript) ==
+        MOONSHINE_ERROR_INVALID_HANDLE);
 }
 
 TEST_CASE("moonshine-phonemes-to-speech-c-api") {

--- a/core/moonshine-c-api.cpp
+++ b/core/moonshine-c-api.cpp
@@ -43,6 +43,7 @@ SOFTWARE.
 #include <cstring>  // For strerror
 #include <filesystem>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <numeric>
 #include <optional>
@@ -69,11 +70,14 @@ SOFTWARE.
 #include "text-embedder.h"
 #include "transcriber.h"
 
-// Defined as a macro to ensure we get meaningful line numbers in the error
-// message.
-#define CHECK_TRANSCRIBER_HANDLE(handle)                                  \
+// Resolves ``handle`` to a ``shared_ptr`` under ``transcriber_map_mutex`` and
+// binds it to ``var``, so callers hold their own reference instead of reading
+// ``transcriber_map`` again later. Defined as a macro to ensure we get
+// meaningful line numbers in the error message.
+#define RESOLVE_TRANSCRIBER_HANDLE(handle, var)                           \
+  std::shared_ptr<Transcriber> var = resolve_transcriber_handle(handle);  \
   do {                                                                    \
-    if (handle < 0 || !transcriber_map.contains(handle)) {                \
+    if (handle < 0 || !var) {                                             \
       LOGF("Moonshine transcriber handle is invalid: handle %d", handle); \
       return MOONSHINE_ERROR_INVALID_HANDLE;                              \
     }                                                                     \
@@ -197,21 +201,36 @@ void parse_transcriber_options(const OptionVector &options,
   }
 }
 
+// ``transcriber_map`` holds a ``shared_ptr`` per handle rather than an owning
+// raw pointer so a concurrent ``moonshine_free_transcriber`` cannot delete the
+// ``Transcriber`` (and its member mutexes) out from under a call that is still
+// in flight on another thread. Every accessor must resolve its own shared_ptr
+// copy under ``transcriber_map_mutex`` via ``resolve_transcriber_handle``
+// (GitHub issue #223); once resolved, the local copy keeps the object alive
+// for the rest of the call even if the handle is freed concurrently.
 std::mutex transcriber_map_mutex;
-std::map<int32_t, Transcriber *> transcriber_map;
+std::map<int32_t, std::shared_ptr<Transcriber>> transcriber_map;
 int32_t next_transcriber_handle = 0;
 
 int32_t allocate_transcriber_handle(Transcriber *transcriber) {
   std::lock_guard<std::mutex> lock(transcriber_map_mutex);
   int32_t transcriber_handle = next_transcriber_handle++;
-  transcriber_map[transcriber_handle] = transcriber;
+  transcriber_map[transcriber_handle] =
+      std::shared_ptr<Transcriber>(transcriber);
   return transcriber_handle;
+}
+
+std::shared_ptr<Transcriber> resolve_transcriber_handle(int32_t handle) {
+  std::lock_guard<std::mutex> lock(transcriber_map_mutex);
+  const auto it = transcriber_map.find(handle);
+  if (it == transcriber_map.end()) {
+    return nullptr;
+  }
+  return it->second;
 }
 
 void free_transcriber_handle(int32_t handle) {
   std::lock_guard<std::mutex> lock(transcriber_map_mutex);
-  delete transcriber_map[handle];
-  transcriber_map[handle] = nullptr;
   transcriber_map.erase(handle);
 }
 
@@ -447,9 +466,9 @@ int32_t moonshine_transcribe_without_streaming(
         transcriber_handle, (void *)(audio_data), audio_length, sample_rate,
         flags, (void *)(out_transcript));
   }
-  CHECK_TRANSCRIBER_HANDLE(transcriber_handle);
+  RESOLVE_TRANSCRIBER_HANDLE(transcriber_handle, transcriber);
   try {
-    transcriber_map[transcriber_handle]->transcribe_without_streaming(
+    transcriber->transcribe_without_streaming(
         audio_data, audio_length, sample_rate, flags, out_transcript);
   } catch (const std::exception &e) {
     LOGF("Failed to transcribe without streaming: %s\n", e.what());
@@ -463,9 +482,9 @@ int32_t moonshine_create_stream(int32_t transcriber_handle, uint32_t flags) {
     LOGF("moonshine_create_stream(transcriber_handle=%d, flags=%d)",
          transcriber_handle, flags);
   }
-  CHECK_TRANSCRIBER_HANDLE(transcriber_handle);
+  RESOLVE_TRANSCRIBER_HANDLE(transcriber_handle, transcriber);
   try {
-    return transcriber_map[transcriber_handle]->create_stream();
+    return transcriber->create_stream();
   } catch (const std::exception &e) {
     LOGF("Failed to create stream: %s\n", e.what());
     return MOONSHINE_ERROR_UNKNOWN;
@@ -478,9 +497,9 @@ int32_t moonshine_free_stream(int32_t transcriber_handle,
     LOGF("moonshine_free_stream(transcriber_handle=%d, stream_handle=%d)",
          transcriber_handle, stream_handle);
   }
-  CHECK_TRANSCRIBER_HANDLE(transcriber_handle);
+  RESOLVE_TRANSCRIBER_HANDLE(transcriber_handle, transcriber);
   try {
-    transcriber_map[transcriber_handle]->free_stream(stream_handle);
+    transcriber->free_stream(stream_handle);
   } catch (const std::exception &e) {
     LOGF("Failed to free stream: %s\n", e.what());
     return MOONSHINE_ERROR_UNKNOWN;
@@ -494,9 +513,9 @@ int32_t moonshine_start_stream(int32_t transcriber_handle,
     LOGF("moonshine_start_stream(transcriber_handle=%d, stream_handle=%d)",
          transcriber_handle, stream_handle);
   }
-  CHECK_TRANSCRIBER_HANDLE(transcriber_handle);
+  RESOLVE_TRANSCRIBER_HANDLE(transcriber_handle, transcriber);
   try {
-    transcriber_map[transcriber_handle]->start_stream(stream_handle);
+    transcriber->start_stream(stream_handle);
   } catch (const std::exception &e) {
     LOGF("Failed to start stream: %s\n", e.what());
     return MOONSHINE_ERROR_UNKNOWN;
@@ -510,9 +529,9 @@ int32_t moonshine_stop_stream(int32_t transcriber_handle,
     LOGF("moonshine_stop_stream(transcriber_handle=%d, stream_handle=%d)",
          transcriber_handle, stream_handle);
   }
-  CHECK_TRANSCRIBER_HANDLE(transcriber_handle);
+  RESOLVE_TRANSCRIBER_HANDLE(transcriber_handle, transcriber);
   try {
-    transcriber_map[transcriber_handle]->stop_stream(stream_handle);
+    transcriber->stop_stream(stream_handle);
   } catch (const std::exception &e) {
     LOGF("Failed to stop stream: %s\n", e.what());
     return MOONSHINE_ERROR_UNKNOWN;
@@ -528,12 +547,12 @@ int32_t moonshine_transcriber_set_keyterms(int32_t transcriber_handle,
         "keyterms='%s')",
         transcriber_handle, keyterms == nullptr ? "" : keyterms);
   }
-  CHECK_TRANSCRIBER_HANDLE(transcriber_handle);
+  RESOLVE_TRANSCRIBER_HANDLE(transcriber_handle, transcriber);
   try {
     const std::vector<std::string> parsed =
         keyterms == nullptr ? std::vector<std::string>()
                             : parse_keyterms(std::string(keyterms));
-    transcriber_map[transcriber_handle]->set_keyterms(parsed);
+    transcriber->set_keyterms(parsed);
   } catch (const std::exception &e) {
     LOGF("Failed to set key terms: %s\n", e.what());
     return MOONSHINE_ERROR_UNKNOWN;
@@ -553,9 +572,9 @@ int32_t moonshine_transcriber_set_context(int32_t transcriber_handle,
         transcriber_handle,
         context == nullptr ? size_t{0} : std::strlen(context), max_terms);
   }
-  CHECK_TRANSCRIBER_HANDLE(transcriber_handle);
+  RESOLVE_TRANSCRIBER_HANDLE(transcriber_handle, transcriber);
   try {
-    transcriber_map[transcriber_handle]->set_context(
+    transcriber->set_context(
         context == nullptr ? std::string() : std::string(context), max_terms);
   } catch (const std::exception &e) {
     LOGF("Failed to set context: %s\n", e.what());
@@ -589,10 +608,10 @@ int32_t moonshine_transcribe_add_audio_to_stream(int32_t transcriber_handle,
         transcriber_handle, stream_handle, (void *)(new_audio_data),
         audio_length, sample_rate, flags);
   }
-  CHECK_TRANSCRIBER_HANDLE(transcriber_handle);
+  RESOLVE_TRANSCRIBER_HANDLE(transcriber_handle, transcriber);
   try {
-    transcriber_map[transcriber_handle]->add_audio_to_stream(
-        stream_handle, new_audio_data, audio_length, sample_rate);
+    transcriber->add_audio_to_stream(stream_handle, new_audio_data,
+                                     audio_length, sample_rate);
   } catch (const std::exception &e) {
     LOGF("Failed to add audio to stream: %s\n", e.what());
     return MOONSHINE_ERROR_UNKNOWN;
@@ -609,10 +628,9 @@ int32_t moonshine_transcribe_stream(int32_t transcriber_handle,
         "flags=%d, out_transcript=%p)",
         transcriber_handle, stream_handle, flags, (void *)(out_transcript));
   }
-  CHECK_TRANSCRIBER_HANDLE(transcriber_handle);
+  RESOLVE_TRANSCRIBER_HANDLE(transcriber_handle, transcriber);
   try {
-    transcriber_map[transcriber_handle]->transcribe_stream(stream_handle, flags,
-                                                           out_transcript);
+    transcriber->transcribe_stream(stream_handle, flags, out_transcript);
   } catch (const std::exception &e) {
     LOGF("Failed to transcribe stream: %s\n", e.what());
     return MOONSHINE_ERROR_UNKNOWN;


### PR DESCRIPTION
Fixes #223.

## What this changes

`transcriber_map` (the global handle table backing every `Transcriber` C-API call) held a raw `Transcriber *` guarded by `transcriber_map_mutex` only inside `allocate_transcriber_handle`/`free_transcriber_handle`. Every other accessor -- `moonshine_transcribe_stream`, `moonshine_transcribe_add_audio_to_stream`, `moonshine_create_stream`, `moonshine_free_stream`, `moonshine_start_stream`, `moonshine_stop_stream`, `moonshine_transcriber_set_keyterms`, `moonshine_transcriber_set_context`, `moonshine_transcribe_without_streaming` -- read the map via the unlocked `CHECK_TRANSCRIBER_HANDLE` macro and then dereferenced `transcriber_map[handle]->method(...)`, also unlocked. If `moonshine_free_transcriber` ran on another thread in between, it deleted the whole `Transcriber` (destroying its member mutexes) and erased the map entry while the other thread's call was still in flight.

That's the crash from #223: `FORTIFY: pthread_mutex_lock called on a destroyed mutex` inside `Transcriber::decode_full`, reached via `transcribe_stream` <- `moonshine_transcribe_stream` <- JNI <- `Transcriber.addAudioToStream` <- `MicTranscriber.audioProcessingLoop`. On the Java side, `MicTranscriber.close()` does call `processing.interrupt()` then `processing.join(1000)` before freeing the transcriber, but `Thread.interrupt()` doesn't preempt an in-flight native call and the join has a hard 1s timeout, so `close()` frees the transcriber anyway once that timeout elapses -- which is also why the crash is intermittent rather than deterministic.

The fix: `transcriber_map` now holds `std::shared_ptr<Transcriber>` instead of an owning raw pointer. A new `resolve_transcriber_handle()` helper (used via a `RESOLVE_TRANSCRIBER_HANDLE` macro that replaces `CHECK_TRANSCRIBER_HANDLE`) resolves and copies the shared_ptr under `transcriber_map_mutex` in one short critical section; every accessor then calls its method on that local copy after releasing the lock. `free_transcriber_handle` now just erases the map entry -- the `Transcriber` is destroyed automatically once the last shared_ptr reference (including any in-flight accessor's copy) drops, instead of racing a manual `delete`. This mirrors the locking pattern already used one layer down in `Transcriber::transcribe_stream` (`core/transcriber.cpp`, for the same class of bug, #218), without serializing concurrent transcription across unrelated `Transcriber` instances.

## How it was tested

Added `moonshine-free-transcriber-races-in-flight-stream-call` to `core/moonshine-c-api-test.cpp`: it drives `moonshine_transcribe_add_audio_to_stream`/`moonshine_transcribe_stream` from a background thread while the main thread calls `moonshine_free_transcriber` mid-flight, then checks that the freed handle reports `MOONSHINE_ERROR_INVALID_HANDLE` on the next call instead of crashing.

Built and ran the new test against a real toolchain (`cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build . --target moonshine-c-api-test -j 8`, project builds with `-Wall -Wextra -pedantic -Werror`, no warnings):

- With the fix, 5 consecutive runs of `./moonshine-c-api-test --test-case="moonshine-free-transcriber-races-in-flight-stream-call"` all report `[doctest] test cases: 1 | 1 passed | 0 failed | 10 skipped` / `[doctest] assertions: 5 | 5 passed | 0 failed |` / `Status: SUCCESS!`.
- With `core/moonshine-c-api.cpp` reverted to its pre-fix state (test kept from this branch), the same test crashes on all 5 runs: `core/moonshine-c-api-test.cpp:826: FATAL ERROR: test case CRASHED: SIGSEGV - Segmentation violation signal`, `Status: FAILURE!` (exit 139).
- A full-binary sanity run with the fix restored (`./moonshine-c-api-test`, all 11 test cases) reports `test cases: 11 | 6 passed | 5 failed | 0 skipped` -- the 5 failures trace to `grapheme-to-phonemizer`/`piper-voice`/`zipvoice` cases missing unrelated `core/moonshine-tts`/data assets that weren't fetched for this narrow verification, and are unrelated to `core/moonshine-c-api.cpp`.

Also ran, both clean: `scripts/check-banned-constructs.sh` and `clang-format --style=file:core/.clang-format --dry-run --Werror` on both touched `.cpp` files (verified the same clang-format command was already clean against the pre-fix baseline, so this isn't masking a pre-existing violation).
