### PR TITLE
Fixed use-after-free race between free_stream and transcribe_stream

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - RP2350 firmware links on Pico SDK versions that pass `-nostartfiles` (undefined `__dso_handle` from libstdc++, GitHub issue #204).
 - Closing a Transcriber while a stream transcription is still running no longer crashes the process (GitHub issue #223).
+- Freeing a stream while a transcription on that same stream is still running no longer crashes the process.
 
 ## [0.1.5]
 

--- a/core/moonshine-c-api-test.cpp
+++ b/core/moonshine-c-api-test.cpp
@@ -890,6 +890,72 @@ TEST_CASE("moonshine-free-transcriber-races-in-flight-stream-call") {
   std::free(wav_data);
 }
 
+// Sibling of the #223 race, one layer down: Transcriber::free_stream deletes
+// the raw TranscriberStream* while holding streams_mutex only around the
+// erase/delete, but Transcriber::transcribe_stream releases streams_mutex
+// after resolving the pointer and then spends the rest of the call (VAD,
+// decode, diarizer) dereferencing that same raw pointer unlocked. A
+// moonshine_free_stream on another thread for the same stream_id can delete
+// the TranscriberStream out from under an in-flight
+// moonshine_transcribe_stream.
+TEST_CASE("moonshine-free-stream-races-in-flight-transcribe-stream-call") {
+  std::string wav_path = "two_cities.wav";
+  REQUIRE(std::filesystem::exists(wav_path));
+  float* wav_data = nullptr;
+  size_t wav_data_size = 0;
+  int32_t wav_sample_rate = 0;
+  REQUIRE(load_wav_data(wav_path.c_str(), &wav_data, &wav_data_size,
+                        &wav_sample_rate));
+  REQUIRE(wav_data != nullptr);
+  REQUIRE(wav_data_size > 0);
+  const size_t clip_samples =
+      std::min(wav_data_size, static_cast<size_t>(wav_sample_rate) * 2);
+
+  std::string root_model_path = "tiny-en";
+  REQUIRE(std::filesystem::exists(root_model_path));
+  int32_t transcriber_handle = moonshine_load_transcriber_from_files(
+      root_model_path.c_str(), MOONSHINE_MODEL_ARCH_TINY, nullptr, 0,
+      MOONSHINE_HEADER_VERSION);
+  REQUIRE(transcriber_handle >= 0);
+
+  int32_t stream_id = moonshine_create_stream(transcriber_handle, 0);
+  REQUIRE(stream_id >= 0);
+  REQUIRE(moonshine_start_stream(transcriber_handle, stream_id) ==
+          MOONSHINE_ERROR_NONE);
+  REQUIRE(moonshine_transcribe_add_audio_to_stream(
+              transcriber_handle, stream_id, wav_data, clip_samples,
+              wav_sample_rate, 0) == MOONSHINE_ERROR_NONE);
+
+  std::atomic<int32_t> transcribe_error{MOONSHINE_ERROR_NONE};
+  std::atomic<bool> started{false};
+  std::thread worker([&]() {
+    started.store(true, std::memory_order_release);
+    struct transcript_t* transcript = nullptr;
+    transcribe_error.store(
+        moonshine_transcribe_stream(transcriber_handle, stream_id,
+                                    MOONSHINE_FLAG_FORCE_UPDATE, &transcript),
+        std::memory_order_release);
+  });
+
+  while (!started.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  // Give the worker time to pass the streams_mutex-protected handle lookup
+  // in transcribe_stream and start using the unlocked raw TranscriberStream*
+  // (VAD/decode), which is where free_stream's delete can now race it.
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  moonshine_free_stream(transcriber_handle, stream_id);
+  worker.join();
+
+  const int32_t in_flight = transcribe_error.load();
+  CHECK((in_flight == MOONSHINE_ERROR_NONE ||
+         in_flight == MOONSHINE_ERROR_INVALID_HANDLE ||
+         in_flight == MOONSHINE_ERROR_UNKNOWN));
+
+  moonshine_free_transcriber(transcriber_handle);
+  std::free(wav_data);
+}
+
 TEST_CASE("moonshine-phonemes-to-speech-c-api") {
   SUBCASE("invalid-handle") {
     float* audio = nullptr;

--- a/core/transcriber.cpp
+++ b/core/transcriber.cpp
@@ -638,9 +638,9 @@ Transcriber::~Transcriber() {
   delete this->streaming_model;
   delete this->speaker_diarizer;
   delete this->spelling_model;
-  for (auto &stream : this->streams) {
-    delete stream.second;
-  }
+  // this->streams holds shared_ptr<TranscriberStream> now, so map
+  // destruction below already deletes each TranscriberStream once no
+  // in-flight accessor still holds a copy.
   if (this->batch_stream != nullptr) {
     delete this->batch_stream;
   }
@@ -695,12 +695,13 @@ int32_t Transcriber::create_stream() {
       this->options.vad_window_duration, this->options.vad_hop_size);
   const size_t vad_max_segment_sample_count =
       vad_sample_count_from_duration(this->options.vad_max_segment_duration);
-  TranscriberStream *stream = new TranscriberStream(
-      new VoiceActivityDetector(this->options.vad_threshold, vad_window_size,
-                                this->options.vad_hop_size,
-                                this->options.vad_look_behind_sample_count,
-                                vad_max_segment_sample_count),
-      stream_id, this->options.save_input_wav_path);
+  std::shared_ptr<TranscriberStream> stream =
+      std::make_shared<TranscriberStream>(
+          new VoiceActivityDetector(this->options.vad_threshold,
+                                    vad_window_size, this->options.vad_hop_size,
+                                    this->options.vad_look_behind_sample_count,
+                                    vad_max_segment_sample_count),
+          stream_id, this->options.save_input_wav_path);
   if (this->speaker_diarizer != nullptr) {
     stream->diarizer_stream_id = this->speaker_diarizer->create_stream();
   }
@@ -709,19 +710,44 @@ int32_t Transcriber::create_stream() {
   return stream_id;
 }
 
-void Transcriber::free_stream(int32_t stream_id) {
+std::shared_ptr<TranscriberStream> Transcriber::resolve_stream(
+    int32_t stream_id) {
   std::lock_guard<std::mutex> lock(this->streams_mutex);
-  TranscriberStream *stream = this->streams[stream_id];
-  this->streams.erase(stream_id);
+  const auto it = this->streams.find(stream_id);
+  if (it == this->streams.end()) {
+    return nullptr;
+  }
+  return it->second;
+}
+
+void Transcriber::free_stream(int32_t stream_id) {
+  // Erase under the lock, but let the TranscriberStream itself be destroyed
+  // outside it once this function's shared_ptr copy goes out of scope. An
+  // in-flight transcribe_stream() call holds its own copy of the same
+  // shared_ptr, so the TranscriberStream stays alive until that call
+  // finishes even though free_stream() has already made it unreachable
+  // through the map (sibling of GitHub issue #223, one layer down).
+  std::shared_ptr<TranscriberStream> stream;
+  {
+    std::lock_guard<std::mutex> lock(this->streams_mutex);
+    const auto it = this->streams.find(stream_id);
+    if (it == this->streams.end()) {
+      return;
+    }
+    stream = std::move(it->second);
+    this->streams.erase(it);
+  }
   if (this->speaker_diarizer != nullptr && stream->diarizer_stream_id >= 0) {
     this->speaker_diarizer->free_stream(stream->diarizer_stream_id);
   }
-  delete stream;
 }
 
 void Transcriber::start_stream(int32_t stream_id) {
-  std::lock_guard<std::mutex> lock(this->streams_mutex);
-  TranscriberStream *stream = this->streams[stream_id];
+  std::shared_ptr<TranscriberStream> stream = this->resolve_stream(stream_id);
+  if (!stream) {
+    throw std::runtime_error("Stream with ID " + std::to_string(stream_id) +
+                             " not found");
+  }
   // Starting a stream invalidates any pointers to stream data (audio, strings)
   // that have been returned to the client during prior sessions.
   {
@@ -739,8 +765,11 @@ void Transcriber::start_stream(int32_t stream_id) {
 }
 
 void Transcriber::stop_stream(int32_t stream_id) {
-  std::lock_guard<std::mutex> lock(this->streams_mutex);
-  TranscriberStream *stream = this->streams[stream_id];
+  std::shared_ptr<TranscriberStream> stream = this->resolve_stream(stream_id);
+  if (!stream) {
+    throw std::runtime_error("Stream with ID " + std::to_string(stream_id) +
+                             " not found");
+  }
   {
     // Refuse further add_audio_to_stream calls, but keep leftover samples and
     // the current VAD utterance open so the next transcribe_stream can drain
@@ -765,8 +794,11 @@ void Transcriber::add_audio_to_stream(int32_t stream_id,
                                       const float *audio_data,
                                       uint64_t audio_length,
                                       int32_t sample_rate) {
-  std::lock_guard<std::mutex> lock(this->streams_mutex);
-  TranscriberStream *stream = this->streams[stream_id];
+  std::shared_ptr<TranscriberStream> stream = this->resolve_stream(stream_id);
+  if (!stream) {
+    throw std::runtime_error("Stream with ID " + std::to_string(stream_id) +
+                             " not found");
+  }
   if (!stream->vad->is_active()) {
     std::string error_message =
         "Adding new audio for stream with ID " + std::to_string(stream_id) +
@@ -778,7 +810,13 @@ void Transcriber::add_audio_to_stream(int32_t stream_id,
 
 void Transcriber::transcribe_stream(int32_t stream_id, uint32_t flags,
                                     struct transcript_t **out_transcript) {
-  TranscriberStream *stream = nullptr;
+  // Resolved as a shared_ptr copy below, entirely under streams_mutex, and
+  // kept alive on the stack for the rest of this call. Earlier this was a
+  // raw pointer, which meant a free_stream() call for the same stream_id on
+  // another thread could delete the TranscriberStream out from under the
+  // VAD/decode/diarizer work below, after streams_mutex was released
+  // (sibling of GitHub issue #223, one layer down).
+  std::shared_ptr<TranscriberStream> stream;
   std::vector<float> audio_snapshot;
   bool should_update = false;
   bool is_stopped = false;
@@ -800,7 +838,7 @@ void Transcriber::transcribe_stream(int32_t stream_id, uint32_t flags,
           std::to_string(this->streams.size()) + " streams: ";
       for (const auto &entry : this->streams) {
         char addr_str[32];
-        snprintf(addr_str, sizeof(addr_str), "%p", (void *)entry.second);
+        snprintf(addr_str, sizeof(addr_str), "%p", (void *)entry.second.get());
         error_message += "ID: " + std::to_string(entry.first) +
                          ", Address: " + std::string(addr_str) + "\n";
       }
@@ -903,7 +941,7 @@ void Transcriber::transcribe_stream(int32_t stream_id, uint32_t flags,
       segments.push_back(std::move(segment_copy));
     }
   }
-  this->update_transcript_from_segments(segments, stream, flags,
+  this->update_transcript_from_segments(segments, stream.get(), flags,
                                         out_transcript);
   if (!this->options.return_audio_data) {
     std::lock_guard<std::mutex> lock(stream->vad_mutex);
@@ -925,7 +963,7 @@ size_t Transcriber::stream_vad_retained_audio_bytes(int32_t stream_id) {
   if (it == this->streams.end() || it->second == nullptr) {
     return 0;
   }
-  TranscriberStream *stream = it->second;
+  const std::shared_ptr<TranscriberStream> &stream = it->second;
   std::lock_guard<std::mutex> vad_lock(stream->vad_mutex);
   return stream->vad->retained_segment_audio_byte_count();
 }
@@ -936,7 +974,7 @@ size_t Transcriber::stream_vad_completed_audio_bytes(int32_t stream_id) {
   if (it == this->streams.end() || it->second == nullptr) {
     return 0;
   }
-  TranscriberStream *stream = it->second;
+  const std::shared_ptr<TranscriberStream> &stream = it->second;
   std::lock_guard<std::mutex> vad_lock(stream->vad_mutex);
   return stream->vad->completed_segment_audio_byte_count();
 }

--- a/core/transcriber.h
+++ b/core/transcriber.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cinttypes>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <random>
 #include <string>
@@ -109,7 +110,8 @@ class TranscriberStream {
   std::string get_wav_filename();
 };
 
-typedef std::map<int32_t, TranscriberStream *> TranscriberStreamMap;
+typedef std::map<int32_t, std::shared_ptr<TranscriberStream>>
+    TranscriberStreamMap;
 
 // Every canonical asset key the keyed in-memory loader
 // (``ModelSource::MEMORY_FILES``, reached through
@@ -337,6 +339,13 @@ class Transcriber {
       const std::vector<SpeakerTurn> &turns, TranscriptStreamOutput *output);
 
  private:
+  // Copies the stream's shared_ptr under streams_mutex and returns it, or
+  // nullptr if stream_id is not in the map. Callers keep the accessor's
+  // work outside the lock on this local copy, so free_stream() erasing the
+  // map entry on another thread cannot delete the TranscriberStream out
+  // from under it (sibling of GitHub issue #223, one layer down).
+  std::shared_ptr<TranscriberStream> resolve_stream(int32_t stream_id);
+
   void update_transcript_from_segments(
       const std::vector<VoiceActivitySegment> &segments,
       TranscriberStream *stream, uint32_t flags,


### PR DESCRIPTION
## What this changes

Sibling of the race fixed in 498fd45 for issue #223, one layer down at the
`TranscriberStream` level.

`Transcriber::free_stream()` (core/transcriber.cpp) held `streams_mutex`
only long enough to erase the map entry and `delete` the
`TranscriberStream*`. `Transcriber::transcribe_stream()` resolved the same
raw pointer under `streams_mutex` (to guard against the map itself, per the
issue #218 comment already in that function) but released the lock before
spending the rest of the call — VAD `process_audio`/`flush`, decode,
diarizer, `transcript_output` access — dereferencing that same pointer
unprotected. A `moonshine_free_stream()` call for the same `stream_id` from
another thread, once `transcribe_stream()` was past the lock, could delete
the `TranscriberStream` (and its owned `VoiceActivityDetector`, since
`~TranscriberStream` does `delete this->vad`) out from under the in-flight
call.

The fix mirrors the pattern `resolve_transcriber_handle()` /
`RESOLVE_TRANSCRIBER_HANDLE` established in `core/moonshine-c-api.cpp` for
498fd45:

- `TranscriberStreamMap` now stores `std::shared_ptr<TranscriberStream>`
  instead of a raw pointer.
- `free_stream()` erases the map entry under `streams_mutex` and lets its
  local `shared_ptr` go out of scope afterward, so an in-flight accessor
  that already copied the `shared_ptr` keeps the `TranscriberStream` alive
  until it finishes.
- `transcribe_stream()` and the other stream accessors (`start_stream`,
  `stop_stream`, `add_audio_to_stream`, `stream_vad_retained_audio_bytes`,
  `stream_vad_completed_audio_bytes`) copy the `shared_ptr` under
  `streams_mutex` and operate on that local copy.

Confined to `core/transcriber.cpp` / `core/transcriber.h`; `batch_stream`
(the separate non-streaming path) is untouched.

## How it was tested

Added `moonshine-free-stream-races-in-flight-transcribe-stream-call` to
`core/moonshine-c-api-test.cpp`, alongside the existing #223 regression
test. It starts a stream, adds audio, spins up a thread that calls
`moonshine_transcribe_stream`, briefly sleeps so the worker is past the
`streams_mutex`-protected handle lookup, then calls `moonshine_free_stream`
for the same stream from the main thread while the worker is still running.

Built and ran with the existing `core/build` tree (`cmake --build . --target
moonshine-c-api-test`), from `test-assets/` with `DYLD_LIBRARY_PATH` pointed
at the built `libmoonshine.dylib` and the vendored ONNX Runtime, on macOS
arm64.

RED (before the fix, source reverted to the current `dev-v0.1.6` tip):

```
core/moonshine-c-api-test.cpp:900: FATAL ERROR: test case CRASHED: SIGSEGV - Segmentation violation signal
[doctest] test cases: 1 | 0 passed | 1 failed | 11 skipped
[doctest] Status: FAILURE!
```
Process exit code 139 (SIGSEGV).

GREEN (with the fix, 5 consecutive runs):

```
[doctest] test cases:  1 |  1 passed | 0 failed | 11 skipped
[doctest] assertions: 10 | 10 passed | 0 failed |
[doctest] Status: SUCCESS!
```
Exit code 0 on every run.

Also ran the full `moonshine-c-api-test` suite (6592 assertions) and
`transcriber-test`: no regressions from this change. Both suites have a
small number of pre-existing failures unrelated to this fix (missing local
Piper/G2P dependency-stem and `tiny-streaming-en` model assets in this
build environment) — confirmed identical on the unmodified source, before
this fix was applied.

Ran `scripts/format-core.sh` and `scripts/check-banned-constructs.sh`
against the touched files; both clean. Added a `CHANGELOGS.md` entry under
`[0.1.6] / Fixed`.